### PR TITLE
Enemy at bottom fix

### DIFF
--- a/mainGame.py
+++ b/mainGame.py
@@ -113,7 +113,7 @@ while running:
             player.is_hit = True
             game_over_sound.play()
             break
-        if enemy.rect.top < 0:
+        if enemy.rect.top > SCREEN_HEIGHT:
             enemies1.remove(enemy)
 
     # 将被击中的敌机对象添加到击毁敌机Group中，用来渲染击毁动画


### PR DESCRIPTION
Enemies weren't removed when they reach bottom of the screen. Instead they were removed when they are over the top of it (which doesn't happen in the gameplay). It caused all enemies to stay in memory even after they flew away.
This fix makes enemies to be removed when the reach the bottom.